### PR TITLE
Init.c SpawnObject Type Bugfix

### DIFF
--- a/DayZEditor/Scripts/4_World/DayZEditor/classes/FileManagers/FileTypes/EditorInitFile.c
+++ b/DayZEditor/Scripts/4_World/DayZEditor/classes/FileManagers/FileTypes/EditorInitFile.c
@@ -75,7 +75,7 @@ class EditorInitFile: EditorFileType
 			spawn_method.Insert("\n\n\/\/ Created Objects");
 		}
 		foreach (EditorObjectData editor_object: data.EditorObjects) {
-			spawn_method.Insert(string.Format("SpawnObject(\"%1\", \"%2\", \"%3\", \"%4\");", editor_object.Type, editor_object.Position.ToString(false), editor_object.Orientation.ToString(false), editor_object.Scale));
+			spawn_method.Insert(string.Format("SpawnObject(\"%1\", \"%2\", \"%3\", %4);", editor_object.Type, editor_object.Position.ToString(false), editor_object.Orientation.ToString(false), editor_object.Scale));
 		}
 		
 		spawn_method.Insert("\n\n\/\/ Uncomment if you want to export loot from newly added buildings");


### PR DESCRIPTION
`SpawnObject` expects `scale` to be of type `float`, we're passing in a string with the way that it was written causing type errors during init.